### PR TITLE
Fix acronym and abbreviation handling in speed reader

### DIFF
--- a/core.js
+++ b/core.js
@@ -224,6 +224,9 @@ document.addEventListener('DOMContentLoaded', (event) => {
 
 //-------------------------------------
 // START of acronym and abbreviation protection functions
+// Note: Uses placeholder technique instead of lookbehind (like numbers in
+// splitIntoSentences) because acronym patterns have variable length which
+// JavaScript regex lookbehind doesn't support
 const PROTECTED_DOT = '\uFFFF'; // Placeholder character for protected dots
 
 // Common abbreviations that shouldn't end a sentence


### PR DESCRIPTION
Fixes: #4 

Problem

  Words like "U.K.", "U.S.", "Mr.", "Dr." were being incorrectly handled:

  1. Sentence splitting: "The U.K. is great" was split into multiple sentences at each dot
  2. Pause detection: Each dot in acronyms triggered an extra pause, making reading choppy

  Solution

  Use a placeholder technique to temporarily protect dots that aren't real sentence endings during text processing.

  Why not use regex lookbehind (like numbers)?
  Numbers use (?<!\d) lookbehind because the pattern is simple and fixed-length. Acronyms have variable-length patterns (U.K. vs U.S.A. vs N.A.T.O.) which JavaScript regex lookbehind doesn't support.

  Changes

  New functions added:
  - protectAcronyms() - Replaces dots in acronyms (U.K., N.A.T.O.) with placeholder character
  - protectAbbreviations() - Replaces dots in common abbreviations (Mr., Dr., Prof., etc.)
  - restoreProtectedDots() - Restores placeholders back to dots for display
  - endsWithSentencePunctuation() - Detects real sentence-ending punctuation vs protected dots

  Key logic:
  - Acronyms at end of sentence ("Lives in the U.K.") → last dot kept real → triggers pause ✓
  - Acronyms mid-sentence ("The U.K. is great") → all dots protected → no pause ✓
  - Abbreviations ("Mr. Smith") → dot protected → no pause ✓

  Files modified: core.js

  Supported abbreviations

  Mr, Mrs, Ms, Dr, Prof, Sr, Jr, vs, etc, approx, Inc, Ltd, Co, Gen, Col, Lt, Sgt, Rev, Hon