### PR TITLE
Add OpenDyslexic font for dyslexia accessibility

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,6 @@
+/* OpenDyslexic Font */
+@import url('https://fonts.cdnfonts.com/css/opendyslexic');
+
 html {
   scroll-behavior: smooth;
 }
@@ -171,7 +174,7 @@ div.lightdarkselector {
 
 /* Font Selector */
 .body-Dyslexia {
-  font-family: 'Comic Sans MS', cursive;
+  font-family: 'OpenDyslexic', 'Comic Sans MS', cursive;
 }
 
 .body-Bionic {


### PR DESCRIPTION
Fixes #6 

Replace Comic Sans MS with proper OpenDyslexic font via CDN import. Comic Sans MS kept as fallback for offline/unsupported cases.

Summary

  Replaced Comic Sans MS with OpenDyslexic, a typeface specifically designed to improve readability for users with dyslexia.

  Why this change?

  - Comic Sans is not a dyslexia font — despite popular belief, it lacks the key features that help dyslexic readers
  - OpenDyslexic is purpose-built — uses weighted bottoms, unique letter shapes, and increased spacing to reduce letter confusion
  - Industry adoption — Amazon Kindle includes OpenDyslexic as one of their accessibility font options

  Changes

  - Added OpenDyslexic via CDN import
  - Updated .body-Dyslexia class with Comic Sans MS as fallback for offline use

  Cost

  - Zero — OpenDyslexic is free and open-source (OFL license)
  - ~50KB additional download when font is selected